### PR TITLE
Fix new session for tmux 3.3

### DIFF
--- a/scripts/switch_session_fzf.sh
+++ b/scripts/switch_session_fzf.sh
@@ -23,7 +23,7 @@ function main {
     fi
     tmux switch-client -t "$session"
   elif [ $retval == 1 ]; then
-    tmux command -p "Press enter to create and go to [$query] session" \
+    tmux command-prompt -b -p "Press enter to create and go to [$query] session" \
       "run '$CURRENT_DIR/make_new_session.sh \"$query\" \"%1\"'"
   fi
 }


### PR DESCRIPTION
As seen in the changelog
https://github.com/tmux/tmux/blob/master/CHANGES
under "CHANGES FROM 3.2a TO 3.3":

> *  Make command-prompt and confirm-before block by default (like run-shell). A
>   new -b flags runs them in the background as before. Also set return code for
>   confirm-before.

This PR adds the `-b` flag to `command-prompt` to make the new session
feature work again. I tested this change with tmux `3.3a` and it seems to work!

Fixes #2
