### PR TITLE
Make window dimensions configurable

### DIFF
--- a/main.tmux
+++ b/main.tmux
@@ -3,7 +3,12 @@
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 default_key_bindings_goto="C-f"
+default_width=50
+default_height=10
+
 tmux_option_goto="@fzf-goto-session"
+tmux_option_width="@fzf-goto-win-width"
+tmux_option_height="@fzf-goto-win-height"
 
 get_tmux_option() {
   local option=$1
@@ -19,9 +24,14 @@ get_tmux_option() {
 function set_goto_session_bindings {
   local key_bindings=$(get_tmux_option "$tmux_option_goto" \
     "$default_key_bindings_goto")
+  local width=$(get_tmux_option "$tmux_option_width" \
+    "$default_width")
+  local height=$(get_tmux_option "$tmux_option_height" \
+    "$default_height")
+
   local key
   for key in $key_bindings; do
-    tmux bind "$key" display-popup -w 50 -h 10 -y 15 -E "$CURRENT_DIR/scripts/switch_session_fzf.sh"
+    tmux bind "$key" display-popup -w "$width" -h "$height" -y 15 -E "$CURRENT_DIR/scripts/switch_session_fzf.sh"
   done
 }
 


### PR DESCRIPTION
New options that can be used in `tmux.conf` are:

```tmux
set -g @fzf-goto-win-width 70
set -g @fzf-goto-win-height 20
```

I tested this out and it works.

Fixes #6
