### PR TITLE
✨ Optional preview window on the side on fzf

### DIFF
--- a/main.tmux
+++ b/main.tmux
@@ -5,62 +5,86 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 default_key_bindings_goto="C-f"
 default_width=55
 default_height=10
-defautl_without_prefix=false
-defautl_search_session_only=false
+default_width_preview=80
+default_height_preview=20
+default_without_prefix=false
+default_search_session_only=false
+default_preview_enabled=false
 
 tmux_option_goto="@fzf-goto-session"
 tmux_option_goto_without_prefix="@fzf-goto-session-without-prefix"
 tmux_option_width="@fzf-goto-win-width"
 tmux_option_height="@fzf-goto-win-height"
+tmux_option_width_preview="@fzf-goto-win-width-preview"
+tmux_option_height_preview="@fzf-goto-win-height-preview"
 tmux_option_search_session_only="@fzf-goto-session-only"
+tmux_option_preview_enabled="@fzf-goto-preview-enabled"
 
 get_tmux_option() {
-	local option=$1
-	local default_value=$2
-	local option_value=$(tmux show-option -gqv "$option")
-	if [ -z "$option_value" ]; then
-		echo "$default_value"
-	else
-		echo "$option_value"
-	fi
+    local option=$1
+    local default_value=$2
+    local option_value=$(tmux show-option -gqv "$option")
+    if [ -z "$option_value" ]; then
+        echo "$default_value"
+    else
+        echo "$option_value"
+    fi
 }
 
 function set_goto_session_bindings {
-	local key_bindings=$(get_tmux_option "$tmux_option_goto" "$default_key_bindings_goto")
-	local without_prefix=$(get_tmux_option "$tmux_option_goto_without_prefix" "$defautl_without_prefix")
-	local width=$(get_tmux_option "$tmux_option_width" "$default_width")
-	local height=$(get_tmux_option "$tmux_option_height" "$default_height")
-	local search_session_only=$(get_tmux_option "$tmux_option_search_session_only" "$defautl_search_session_only")
+    local key_bindings=$(get_tmux_option "$tmux_option_goto" "$default_key_bindings_goto")
+    local without_prefix=$(get_tmux_option "$tmux_option_goto_without_prefix" "$default_without_prefix")
+    local search_session_only=$(get_tmux_option "$tmux_option_search_session_only" "$default_search_session_only")
+    local preview_enabled=$(get_tmux_option "$tmux_option_preview_enabled" "$default_preview_enabled")
 
+    # Determine width and height based on whether preview is enabled
+    local width
+    local height
 
-	if [ "$search_session_only" = false ]; then
-		if [ "$without_prefix" = true ]; then
-			local key
-			for key in $key_bindings; do
-				tmux bind -n "$key" display-popup -w "$width" -h "$height" -y 15 -E "$CURRENT_DIR/scripts/switch_session_window.sh"
-			done
-		else
-			local key
-			for key in $key_bindings; do
-				tmux bind "$key" display-popup -w "$width" -h "$height" -y 15 -E "$CURRENT_DIR/scripts/switch_session_window.sh"
-			done
-		fi
-	else
-		if [ "$without_prefix" = true ]; then
-			local key
-			for key in $key_bindings; do
-				tmux bind -n "$key" display-popup -w "$width" -h "$height" -y 15 -E "$CURRENT_DIR/scripts/switch_session.sh"
-			done
-		else
-			local key
-			for key in $key_bindings; do
-				tmux bind "$key" display-popup -w "$width" -h "$height" -y 15 -E "$CURRENT_DIR/scripts/switch_session.sh"
-			done
-		fi
-	fi
+    if [ "$preview_enabled" = true ]; then
+        width=$(get_tmux_option "$tmux_option_width_preview" "$default_width_preview")
+        height=$(get_tmux_option "$tmux_option_height_preview" "$default_height_preview")
+    else
+        width=$(get_tmux_option "$tmux_option_width" "$default_width")
+        height=$(get_tmux_option "$tmux_option_height" "$default_height")
+    fi
+
+    # Pass the preview_enabled option to the scripts as an environment variable
+    local preview_option=""
+    if [ "$preview_enabled" = true ]; then
+        preview_option="PREVIEW_ENABLED=1"
+    else
+        preview_option="PREVIEW_ENABLED=0"
+    fi
+
+    if [ "$search_session_only" = false ]; then
+        if [ "$without_prefix" = true ]; then
+            local key
+            for key in $key_bindings; do
+                tmux bind -n "$key" display-popup -w "$width" -h "$height" -y 15 -E "$preview_option $CURRENT_DIR/scripts/switch_session_window.sh"
+            done
+        else
+            local key
+            for key in $key_bindings; do
+                tmux bind "$key" display-popup -w "$width" -h "$height" -y 15 -E "$preview_option $CURRENT_DIR/scripts/switch_session_window.sh"
+            done
+        fi
+    else
+        if [ "$without_prefix" = true ]; then
+            local key
+            for key in $key_bindings; do
+                tmux bind -n "$key" display-popup -w "$width" -h "$height" -y 15 -E "$preview_option $CURRENT_DIR/scripts/switch_session.sh"
+            done
+        else
+            local key
+            for key in $key_bindings; do
+                tmux bind "$key" display-popup -w "$width" -h "$height" -y 15 -E "$preview_option $CURRENT_DIR/scripts/switch_session.sh"
+            done
+        fi
+    fi
 }
 
 function main {
-	set_goto_session_bindings
+    set_goto_session_bindings
 }
 main

--- a/scripts/preview_session.sh
+++ b/scripts/preview_session.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+#TODO: add tests and help instructions  
+
+session_name="${1}"
+
+# Get the session ID using the session name
+session_id=$(tmux list-sessions -F '#{session_id}:#{session_name}' | awk -F':' -v name="$session_name" '$2 == name {print $1}')
+
+if [ -z "${session_id}" ]; then
+  echo "Unknown session: ${session_name}"
+  exit 1
+fi
+
+# Get the active pane of the session
+active_pane=$(tmux list-panes -t "${session_name}" -F '#{pane_id} #{pane_active}' | awk '$2 == "1" {print $1}')
+
+if [ -z "${active_pane}" ]; then
+  echo "No active pane found for session ${session_name}"
+  exit 1
+fi
+
+# Display the contents of the session's active pane
+tmux capture-pane -ep -t "${active_pane}"

--- a/scripts/preview_session.sh
+++ b/scripts/preview_session.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-#TODO: add tests and help instructions  
-
 session_name="${1}"
 
 # Get the session ID using the session name

--- a/scripts/preview_window.sh
+++ b/scripts/preview_window.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+window_id="${1}"
+
+if [ -z "${window_id}" ]; then
+  echo "No window ID provided"
+  exit 1
+fi
+
+# Get the active pane of the window
+active_pane=$(tmux list-panes -t "${window_id}" -F '#{pane_id} #{pane_active}' | awk '$2 == "1" {print $1}')
+
+if [ -z "${active_pane}" ]; then
+  echo "No active pane found for window ${window_id}"
+  exit 1
+fi
+
+# Display the contents of the window's active pane
+tmux capture-pane -ep -t "${active_pane}"

--- a/scripts/switch_session.sh
+++ b/scripts/switch_session.sh
@@ -3,28 +3,35 @@
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 function main {
-  local sessions
-  local session
-  local query
-  local sess_arr
-  local retval
-  sessions=$(tmux list-sessions -F "#{session_name}" |
-    fzf --exit-0 --print-query --reverse)
-  retval=$?
+    local sessions
+    local session
+    local query
+    local sess_arr
+    local retval
 
-  IFS=$'\n' read -rd '' -a sess_arr <<<"$sessions"
+    local fzf_command=(fzf --exit-0 --print-query --reverse)
 
-  session=${sess_arr[1]}
-  query=${sess_arr[0]}
-
-  if [ $retval == 0 ]; then
-    if [ "$session" == "" ]; then
-      session="$query"
+    if [ "${PREVIEW_ENABLED}" = "1" ]; then
+        fzf_command+=(--preview "$CURRENT_DIR/preview_session.sh {}" --preview-window=right:60%)
     fi
-    tmux switch-client -t "$session"
-  elif [ $retval == 1 ]; then
-    tmux command-prompt -b -p "Press enter to create and go to [$query] session" \
-      "run '$CURRENT_DIR/make_new_session.sh \"$query\" \"%1\"'"
-  fi
+
+    sessions=$(tmux list-sessions -F "#{session_name}" | "${fzf_command[@]}")
+    retval=$?
+
+    IFS=$'\n' read -rd '' -a sess_arr <<<"$sessions"
+
+    session=${sess_arr[1]}
+    query=${sess_arr[0]}
+
+    if [ $retval -eq 0 ]; then
+        if [ -z "$session" ]; then
+            session="$query"
+        fi
+        tmux switch-client -t "$session"
+    elif [ $retval -eq 1 ]; then
+        tmux command-prompt -b -p "Press enter to create and go to [$query] session" \
+            "run '$CURRENT_DIR/make_new_session.sh \"$query\" \"%1\"'"
+    fi
 }
+
 main

--- a/scripts/switch_session_window.sh
+++ b/scripts/switch_session_window.sh
@@ -3,28 +3,35 @@
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 function main {
-  local sessions
-  local session
-  local query
-  local sess_arr
-  local retval
-  sessions=$(tmux list-windows -a | 
-    fzf --exit-0 --print-query --reverse)
-  retval=$?
+    local windows
+    local window
+    local query
+    local win_arr
+    local retval
 
-  IFS=$'\n' read -rd '' -a sess_arr <<<"$sessions"
+    local fzf_command=(fzf --exit-0 --print-query --reverse --delimiter=":" --with-nth=1,2,4)
 
-  session=$(echo ${sess_arr[1]} | sed 's/: .*//g')
-  query=${sess_arr[0]}
-
-  if [ $retval == 0 ]; then
-    if [ "$session" == "" ]; then
-        session=$(echo "$query" | sed 's/: .*//g')
+    if [ "${PREVIEW_ENABLED}" = "1" ]; then
+        fzf_command+=(--preview "$CURRENT_DIR/preview_window.sh {1}" --preview-window=right:60%)
     fi
-    tmux switch-client -t "$session"
-  elif [ $retval == 1 ]; then
-    tmux command-prompt -b -p "Press enter to create and go to [$query] session" \
-      "run '$CURRENT_DIR/make_new_session.sh \"$query\" \"%1\"'"
-  fi
+
+    windows=$(tmux list-windows -a -F "#{session_name}:#{window_index}: #{window_name}" | "${fzf_command[@]}")
+    retval=$?
+
+    IFS=$'\n' read -rd '' -a win_arr <<<"$windows"
+
+    window="${win_arr[1]}"
+    query="${win_arr[0]}"
+
+    if [ $retval -eq 0 ]; then
+        if [ -z "$window" ]; then
+            window="$query"
+        fi
+        tmux switch-client -t "$window"
+    elif [ $retval -eq 1 ]; then
+        tmux command-prompt -b -p "Press enter to create and go to [$query] window" \
+            "run '$CURRENT_DIR/make_new_window.sh \"$query\" \"%1\"'"
+    fi
 }
+
 main


### PR DESCRIPTION
- Introduce new tmux option '@fzf-goto-preview-enabled' to control the preview feature (default: true)
- Introduce new tmux option '@fzf-goto-preview-{width/height}-preview' to control the preview width and height
- Update 'main.tmux' to pass the preview option to scripts via an environment variable
- Modify 'switch_session.sh' and 'switch_session_window.sh' to conditionally include the preview in 'fzf' based on the option
- Refactor scripts to use arrays for building 'fzf' commands for safer argument handling
- Fix typos in variable names (e.g., 'defautl' to 'default') and comments

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/512b0025-9d98-4895-978a-05bc44d6342a">

